### PR TITLE
Fix incorrect case in test for last buildList

### DIFF
--- a/algoToolBox/algoToolBox.ipynb
+++ b/algoToolBox/algoToolBox.ipynb
@@ -295,7 +295,7 @@
    },
    "outputs": [],
    "source": [
-    "buildlist(5), buildList(5, 0), buildList(5, alea=(0,10))"
+    "buildList(5), buildList(5, 0), buildList(5, alea=(0,10))"
    ]
   },
   {


### PR DESCRIPTION
The casing was incorrect, as calling `buildlist` would execute one of the earlier versions, not the fully "pythonerized" version.